### PR TITLE
修改useMiddleActions接口，middleWare接口

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-reducer",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "./index.js",
   "author": "Jimmy.Harding",
   "description": "the purpose of this project is using an agent object or class to play as a reducer",

--- a/src/libs/middleActions.type.ts
+++ b/src/libs/middleActions.type.ts
@@ -2,7 +2,7 @@ import {agentDependenciesKey} from "./defines";
 import {AgentDependencies} from "./agent.type";
 import {Env, OriginAgent, MiddleWare, LifecycleMiddleWare} from "./global.type";
 
-export interface AsyncAgent<S, T extends OriginAgent<S>> {
+export interface MiddleActionsInterface<T extends OriginAgent<S>,S> {
     agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> },
 
     [key: string]: any

--- a/src/libs/useMiddleWare.ts
+++ b/src/libs/useMiddleWare.ts
@@ -12,10 +12,28 @@ import {createProxy} from "./util";
  * @param mdw
  */
 export function branch<S, T extends OriginAgent<S>>(agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> }, mdw: MiddleWare | LifecycleMiddleWare): T {
-    return useMiddleWare(agent, mdw);
+    return copyWithMiddleWare(agent, mdw,'copy');
 }
 
-export function useMiddleWare<S, T extends OriginAgent<S>>(agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> }, mdw: MiddleWare | LifecycleMiddleWare): T {
+export function useMiddleWare<S, T extends OriginAgent<S>>(
+    agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> },
+    mdw: MiddleWare | LifecycleMiddleWare
+): T {
+    return copyWithMiddleWare(agent,mdw,'copy');
+}
+
+export function decorateWithMiddleWare<S, T extends OriginAgent<S>>(
+    agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> },
+    mdw: MiddleWare | LifecycleMiddleWare
+): T  {
+    return copyWithMiddleWare(agent,mdw,'decorator');
+}
+
+export function copyWithMiddleWare<S, T extends OriginAgent<S>>(
+    agent: T & { [agentDependenciesKey]?: AgentDependencies<S, T> },
+    mdw: MiddleWare | LifecycleMiddleWare,
+    copyType:'copy'|'decorator'
+): T {
 
     let agentCloned: T;
 
@@ -54,7 +72,7 @@ export function useMiddleWare<S, T extends OriginAgent<S>>(agent: T & { [agentDe
                 return source;
             }
         });
-        return generateAgent(entry, store, cloneEnvProxy, applyMiddleWares(mdw, middleWare), true);
+        return generateAgent(entry, store, cloneEnvProxy, applyMiddleWares(mdw, middleWare), {sourceAgent:agent,type:copyType});
     };
 
     agentCloned = cloneAgentWithNewExpired();


### PR DESCRIPTION
1. useMiddleActions 支持 MiddleActions class 写法或对象写法 new MiddleActions(agent)

2. class 内部的 middleWare 能覆盖外部使用 useMiddleWare 加入的 middleWare