### PR TITLE
## v3.7.0 2021-07-27

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -74,3 +74,8 @@ in this version, `runtime.cache` used in MiddleWare is independent.
 ## v3.6.3 2021-07-13
 
 * [bug] fix the problem about state modified by a notified action.
+
+## v3.7.0 2021-07-27
+
+* [design] the weakSharing agent can change model state whether it is destroyed or not, only when all the sharing agents are destroyed.
+* [design] add the `initial` callback to the weakSharing API returns. 

--- a/CHANGE_LOG_ZH.md
+++ b/CHANGE_LOG_ZH.md
@@ -82,3 +82,8 @@
 ## v3.6.3 2021-07-13
 
 * [bug] 修正关于通知类 action 修改 state ，导致 state 回滚的问题。
+
+## v3.7.0 2021-07-27
+
+* [design] 在 weakSharing 模式下，除非所有共享代理全部销毁，否则就可以更改模型的 state，但外部 state 更新依旧依赖于当前 agent 是否被销毁。
+* [design] weakSharing API 返回对象属性中增加了 initial 回调。

--- a/documents/en/api/weak_sharing.md
+++ b/documents/en/api/weak_sharing.md
@@ -7,10 +7,34 @@ function weakSharing<
     S,
     T extends OriginAgent<S> = OriginAgent<S>
     >(
-  factory:()=>T|{new ():T},
-):{current:T}
+  factory: (...args:any[]) => T | { new (): T; },
+):{current:T,initial:(...args:any[])=>T}
 ```
 
 * factory - a factory callback function for generating a model（class or object）
   
-It returns a wrap object which contains a weak persistent model at property `current`. When `Agents` from this model are all destroyed, the factory callback generates a new one.
+It returns a wrap object which contains a weak persistent model at property `current`. When `Agents` from this model are all destroyed, the factory callback generates a new one. Another property function from the object is `initial` , and this function is used to pass params into model, when you need to initial it. The `initial` function always runs when your model hasn't initialed or it has been reseted yet, otherwise it returns the weak persistent model just like `current` .
+
+```typescript
+import {createAgentReducer,weakSharing,OriginAgent} from 'agent-reducer';
+
+class Model implements OriginAgent<State>{
+
+  constructor(param:any){
+    this.state = doSomeThing(param);
+  }
+
+  method(){
+    return doSomeThing(this.state);
+  }
+
+}
+
+const modelRef = weakSharing((param:any)=>new Model(param));
+
+// The `initial` function always runs when your model hasn't initialed or it has been reseted yet,
+// otherwise it returns the weak persistent model just like `current` .
+const {agent} = createAgentReducer(modelRef.initial({data:...}));
+
+const {agent:ag} = createAgentReducer(modelRef.current);
+```

--- a/documents/zh/api/weak_sharing.md
+++ b/documents/zh/api/weak_sharing.md
@@ -7,10 +7,34 @@ function weakSharing<
     S,
     T extends OriginAgent<S> = OriginAgent<S>
     >(
-  factory:()=>T|{new ():T},
-):{current:T}
+  factory: (...args:any[]) => T | { new (): T; },
+):{current:T,initial:(...args:any[])=>T}
 ```
 
 * factory - 生成共享模型的工厂方法，通过该方法返回一个被共享的模型（class 或 object）
   
-该方法返回一个弱持久化共享模型包装，从返回值的 `current` 属性中可取出模型，当模型生成的 `Agent` 代理全被销毁时，模型会通过传入的  factory 工厂方法进行模型重置。
+该方法返回一个弱持久化共享模型包装，从返回值的 `current` 属性中可取出模型，当模型生成的 `Agent` 代理全被销毁时，模型会通过传入的 factory 工厂方法进行模型重置；`initial` 属性允许使用者在首次初始化时进行传参。注意只有在agent未初始化或被重置后，初始化才有效，否则  `initial` 直接返回当前已初始化好的模型对象。
+
+```typescript
+import {createAgentReducer,weakSharing,OriginAgent} from 'agent-reducer';
+
+class Model implements OriginAgent<State>{
+
+  constructor(param:any){
+    this.state = doSomeThing(param);
+  }
+
+  method(){
+    return doSomeThing(this.state);
+  }
+
+}
+
+const modelRef = weakSharing((param:any)=>new Model(param));
+
+// 在需要初始化的地方进行初始化，注意只有在agent未初始化或被重置后，初始化才有效，
+// 否则 modelRef.initial({data:...}) 直接返回当前已初始化好的模型对象
+const {agent} = createAgentReducer(modelRef.initial({data:...}));
+
+const {agent:ag} = createAgentReducer(modelRef.current);
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,9 +118,10 @@ export declare function sharing<S, T extends OriginAgent<S> = OriginAgent<S>>(fa
     current: T;
 };
 export declare function weakSharing<S, T extends OriginAgent<S> = OriginAgent<S>>(
-    factory: () => T | { new (): T; }
+    factory: (...args:any[]) => T | { new (): T; }
 ): {
     current: T;
+    initial:(...args:any[])=>T;
 };
 export declare function createAgentReducer<S, T extends OriginAgent<S> = OriginAgent<S>>(
     originAgent: T | { new (): T; },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-reducer",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "main": "./index.js",
   "author": "Jimmy.Harding",
   "description": "the purpose of this project is using a class to replace a reducer",

--- a/test/en/api/createAgentReducer.spec.ts
+++ b/test/en/api/createAgentReducer.spec.ts
@@ -63,7 +63,7 @@ describe('how to use createAgentReducer', () => {
         // createAgentReducer has a simple reducer processor inside.
         const {agent} = createAgentReducer(CountAgent, {expired: true});
         await agent.increase();
-        expect(agent.state).toBe(0);
+        expect(agent.state).toBe(1);
     });
 
     it('use both MiddleWare and env directly on createAgentReducer', async () => {

--- a/test/guarantee/sharing.test.ts
+++ b/test/guarantee/sharing.test.ts
@@ -1,0 +1,36 @@
+import {OriginAgent, createAgentReducer, weakSharing} from "../../src";
+
+type User = { id: number; name: string };
+
+describe("修补reducer测试", () => {
+    class ObjectAgent implements OriginAgent<User> {
+        state:User;
+
+        constructor(id:number) {
+            this.state={ id, name: "" };
+        }
+
+        rename = (name: string) => {
+            return { ...this.state, name };
+        };
+    }
+
+    const ref = weakSharing((id:number)=>new ObjectAgent(id));
+
+    test("简单传参", () => {
+        const { agent } = createAgentReducer(new ObjectAgent(0));
+        agent.rename("name");
+        expect(agent.state.name).toBe("name");
+        expect(agent.state.id).toBe(0);
+    });
+
+    test("共享传参", () => {
+        const { agent } = createAgentReducer(ref.initial(1));
+        const { agent:ag } = createAgentReducer(ref.initial(2));
+        agent.rename("name");
+        expect(agent.state.name).toBe("name");
+        expect(agent.state.id).toBe(1);
+        expect(ag.state.id).toBe(1);
+        expect(ag.state.name).toBe('name');
+    });
+});

--- a/test/zh/api/createAgentReducer.spec.ts
+++ b/test/zh/api/createAgentReducer.spec.ts
@@ -66,7 +66,7 @@ describe('如何使用 API createAgentReducer', () => {
         // createAgentReducer 自带一个简单的内置 reducer 处理器
         const {agent} = createAgentReducer(CountAgent, {expired: true});
         await agent.increase();
-        expect(agent.state).toBe(0);
+        expect(agent.state).toBe(1);
     });
 
     it('直接在createAgentReducer上同时使用MiddleWare和运行环境env配置', async () => {


### PR DESCRIPTION
* [design] the weakSharing agent can change model state whether it is destroyed or not, only when all the sharing agents are destroyed.
* [design] add the `initial` callback to the weakSharing API returns.