### PR TITLE
# 4.2.1 2022-03-17

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -645,14 +645,14 @@ To check more [details](/guides?id=effect).
 
 ## effect
 
-The `ES6 decorator` usage of [addEffect](/api?id=addeffect). It makes the working instance of current class as effect target. If you want to listen to the state changes from a specific method, you can give it a method as param.
+The `ES6 decorator` usage of [addEffect](/api?id=addeffect). It makes the working instance of current class as effect target. If you want to listen to the state changes from a specific method, you can give it a callback which returns method as param.
 
 ```typescript
 export declare function effect<S=any, T extends Model<S>=Model>(
-    method?:(...args:any[])=>any,
+    method?:()=>(...args:any[])=>any,
 ):MethodDecoratorCaller
 ```
 
-* method - optional, it should come from the current model class: `Class.prototype.method`.
+* method - optional, a callback which returns `Class.prototype.method` as the target method for state change listening.
 
 To check more [details](/guides?id=effect-decorator).

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -155,3 +155,8 @@ in this version, `runtime.cache` used in MiddleWare is independent.
 * [optimize] use linked list to control the action consuming
 * [api] add new API [addEffect](/zh/api?id=addeffect)
 * [api] add new API [effect](/zh/api?id=effect)
+
+# 4.2.1 2022-03-17
+
+* [design] modify effect decorator param pattern, use as `()=>Class.prototype.method`.
+* [design] effect decorator has support multi target methods to one `effect method` .

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -650,7 +650,7 @@ describe('the basic usage about effect', () => {
 
 ### Effect decorator
 
-If you want to add effect inside model, and start it after this model is connected, you can use api [effect](/api?id=effect) to decorate a model method to be a effect callback. If you pass nothing into [effect](/api?id=effect) decorator, it will take current model instance as the listening target. If you pass a method of current model into [effect](/api?id=effect) decorator as a param, it will only listen to the state changes leaded by this specific `method`.
+If you want to add effect inside model, and start it after this model is connected, you can use api [effect](/api?id=effect) to decorate a model method to be a effect callback. If you pass nothing into [effect](/api?id=effect) decorator, it will take current model instance as the listening target. If you pass a callback which returns a method of current model into [effect](/api?id=effect) decorator as a param, it will only listen to the state changes leaded by this specific `method`.
 
 The method decorated by [effect](/api?id=effect) is bind on an `agent` which is created temporary from current `model instance`. So, if deploy the method from keyword `this` in a effect callback, it will change the model state.
 
@@ -700,7 +700,7 @@ describe("use decorator effect",()=>{
 
         // give a method as effect param,
         // the decorated method will only be triggered by the param method state changes.
-        @effect(InnerCountModel.prototype.increase)
+        @effect(()=>InnerCountModel.prototype.increase)
         ltFiveEffect(prevState:number, state:number){
             if(state>4){
                 // the keyword `this` is a temporary `agent` from model

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -631,14 +631,14 @@ export declare function addEffect<S=any, T extends Model<S> = Model>(
 
 ## effect
 
-[addEffect](/zh/api?id=addeffect) API 的 `ES6 decorator` 模式。添加该 decorator 装饰器的模型方法会被当作`副作用回调函数`，监听目标默认为当前模型实例，而 `effect` 入参`模型方法`将被当作被监听的目标方法。
+[addEffect](/zh/api?id=addeffect) API 的 `ES6 decorator` 模式。添加该 decorator 装饰器的模型方法会被当作`副作用回调函数`，监听目标默认为当前模型实例，而 `effect` 入参函数返回的`模型方法`将被当作被监听的目标方法。
 
 ```typescript
 export declare function effect<S=any, T extends Model<S>=Model>(
-    method?:(...args:any[])=>any,
+    method?:()=>(...args:any[])=>any,
 ):MethodDecoratorCaller
 ```
 
-* method - 可选，被监听的目标方法，必须为当前模型方法。
+* method - 可选，返回被监听的目标方法的回调函数，必须为当前模型方法。
 
 查看更多[细节](/zh/guides?id=副作用-decorator-装饰器用法)。

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -163,3 +163,8 @@
 * [optimize] 使用链表形式控制 action 的非重叠运行过程。
 * [api] 新增 [addEffect](/zh/api?id=addeffect) API
 * [api] 新增 [effect](/zh/api?id=effect) API
+
+# 4.2.1 2022-03-17
+
+* [design] 修改 effect decorator 传参用法，不在直接使用 `Class.prototype.method` ，改用 `()=>Class.prototype.method`
+* [design] effect decorator 支持对一个 `effect method` 追加多个监听方法

--- a/docs/zh/guides.md
+++ b/docs/zh/guides.md
@@ -637,7 +637,7 @@ describe('effect 基本用法', () => {
 
 ### 副作用 decorator 装饰器用法
 
-添加副作用的 decorator API 为 [effect](/zh/api?id=effect)。被该 decorator 函数修饰的方法将被作为副作用回调来使用，而副作用监听目标默认为当前模型实例：`effect()`，如传入当前模型方法，则监听该目标下的指定方法：`effect(Model.prototype.method)`。
+添加副作用的 decorator API 为 [effect](/zh/api?id=effect)。被该 decorator 函数修饰的方法将被作为副作用回调来使用，而副作用监听目标默认为当前模型实例：`effect()`，如传入当前模型方法提供函数，则监听该目标下的指定方法：`effect(()=>Model.prototype.method)`。
 
 装饰器副作用回调方法会在触发时被绑定到一个临时创建的当前模型代理 agent 对象上。所以该方法中的关键词 `this` 是个代理对象。这方便使用者在回调方法中调用其他方法，从而修改 state 数据。
 
@@ -684,7 +684,7 @@ describe("使用 effect decorator API",()=>{
 
         // 当 effect 入参为当前 class 的方法时，
         // 监听目标为当前入参方法
-        @effect(InnerCountModel.prototype.increase)
+        @effect(()=>InnerCountModel.prototype.increase)
         ltFiveEffect(prevState:number, state:number){
             if(state>4){
                 this.reset(4);

--- a/index.d.ts
+++ b/index.d.ts
@@ -177,7 +177,7 @@ export declare function addEffect<S=any, T extends Model<S> = Model>(
 ):EffectWrap<S, T>;
 
 export declare function effect<S=any, T extends Model<S>=Model>(
-    method?:(...args:any[])=>any,
+    method?:()=>(...args:any[])=>any,
 ):MethodDecoratorCaller
 
 export class MiddleWares {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-reducer",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "main": "dist/agent-reducer.mini.js",
   "typings": "index.d.ts",
   "author": "Jimmy.Harding",

--- a/src/libs/global.type.ts
+++ b/src/libs/global.type.ts
@@ -97,10 +97,12 @@ export type DecoratorCaller = (target: any, p?: string)=>any;
 
 export type MethodDecoratorCaller = (target: any, p: string)=>any;
 
+export type EffectDecoratorTargetMethod = ()=>((...args:any[])=>any);
+
 export type EffectDecoratorCallback<S=any, T extends Model<S>=Model> = (
     (...args:any[])=>any
     )&{
-  [agentCallingEffectTargetKey]?:(EffectCallback<S, T>)|string
+  [agentCallingEffectTargetKey]?:Array<EffectDecoratorTargetMethod|string>
 };
 
 export type EffectMethod<S=any, T extends Model<S>=Model> = EffectDecoratorCallback<S, T>;

--- a/test/en/effect.test.ts
+++ b/test/en/effect.test.ts
@@ -198,7 +198,7 @@ describe("use decorator effect",()=>{
 
         // give a method as effect param,
         // the decorated method will only be triggered by the param method state changes.
-        @effect(InnerCountModel.prototype.increase)
+        @effect(()=>InnerCountModel.prototype.increase)
         ltFiveEffect(prevState:number, state:number){
             if(state>4){
                 // the keyword `this` is a temporary `agent` from model

--- a/test/guard/middleWarePresets.test.ts
+++ b/test/guard/middleWarePresets.test.ts
@@ -45,12 +45,12 @@ describe('guard middleWarePresets', () => {
             }, lazyTime));
         }
 
-        @effect(UserModel.prototype.login)
+        @effect(()=>UserModel.prototype.login)
         loginEffect() {
             this.fetchUser();
         }
 
-        @effect(UserModel.prototype.logout)
+        @effect(()=>UserModel.prototype.logout)
         logoutEffect(){
             this.cleanUser();
         }

--- a/test/zh/effect.test.ts
+++ b/test/zh/effect.test.ts
@@ -192,7 +192,7 @@ describe("使用 effect decorator API",()=>{
 
         // 当 effect 入参为当前 class 的方法时，
         // 监听目标为当前入参方法
-        @effect(InnerCountModel.prototype.increase)
+        @effect(()=>InnerCountModel.prototype.increase)
         ltFiveEffect(prevState:number, state:number){
             if(state>4){
                 this.reset(4);


### PR DESCRIPTION
* [design] modify effect decorator param pattern, use as `()=>Class.prototype.method`.
* [design] effect decorator has support multi target methods to one `effect method` .