### PR TITLE
# 4.6.1 2022-07-27

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "none",

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -217,3 +217,7 @@ in this version, `runtime.cache` used in MiddleWare is independent.
 # 4.6.0 2022-06-27
 
 * [design] add [strict](/api?id=strict), [act](/api?id=act) API.
+
+# 4.6.1 2022-07-27
+
+* [bug] resolve the problem about typescript support for `sharing.initial` returning.

--- a/docs/zh/changes.md
+++ b/docs/zh/changes.md
@@ -225,3 +225,7 @@
 # 4.6.0 2022-06-27
 
 * [design] 体验版 API [strict](/zh/api?id=strict), [act](/zh/api?id=act) 转正。
+
+# 4.6.1 2022-07-27
+
+* [bug] 解决 typescript 对 `sharing` 或 `weakSharing` 提供的 `initial` 方法返回值支持差的问题。

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ export declare type SharingRef<
     T extends Model<S>= Model<S>,
     > = {
     current:T,
-    initial:Factory<S, T>
+    initial:(...args:any[])=>T
 };
 
 export declare function sharing<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-reducer",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "main": "dist/agent-reducer.mini.js",
   "typings": "index.d.ts",
   "author": "Jimmy.Harding",

--- a/src/libs/sharing.type.ts
+++ b/src/libs/sharing.type.ts
@@ -18,7 +18,7 @@ export type SharingRef<
     T extends OriginAgent<S>= OriginAgent<S>,
     > = {
     current:T,
-    initial:Factory<S, T>
+    initial:(...args:any[])=>T
 }
 
 export type ModelConnector<


### PR DESCRIPTION
* [bug] resolve the problem about typescript support for `sharing.initial` returning.